### PR TITLE
Quote variables, ignore SSL, fix grammar

### DIFF
--- a/migrate
+++ b/migrate
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 ####### Project name 
 PROJECT_NAME="myproject"
 EMAIL="mycompany.com"
@@ -28,17 +29,16 @@ RED='\033[0;31m';
 LIGHT_GREEN='\e[1;32m';
 NC='\033[0m' # No Color
 
+# General Configuration
+ABSOLUTE_PATH="$(pwd)"
+TMP="${ABSOLUTE_PATH}/migration-${PROJECT_NAME}"
 
-# Geral Configuration
-ABSOLUTE_PATH=$(pwd)
-TMP=$ABSOLUTE_PATH/"migration-"$PROJECT_NAME
+# Branches Configuration
+SVN_BRANCHES="${BASE_SVN}/${BRANCHES}"
+SVN_TAGS="${BASE_SVN}/${TAGS}"
+SVN_TRUNK="${BASE_SVN}/${TRUNK}"
 
-# Branchs Configuration
-SVN_BRANCHES=$BASE_SVN/$BRANCHES
-SVN_TAGS=$BASE_SVN/$TAGS
-SVN_TRUNK=$BASE_SVN/$TRUNK
-
-AUTHORS=$PROJECT_NAME"-authors.txt"
+AUTHORS="${PROJECT_NAME}-authors.txt"
 
 echo -e "${LIGHT_GREEN} [LOG] Starting migration of ${NC}" $SVN_TRUNK
 echo -e "${LIGHT_GREEN} [LOG] Using: ${NC}" $(git --version)
@@ -48,59 +48,61 @@ echo
 echo -e "${LIGHT_GREEN} [LOG] Step 01/08 Create Directories ${NC}" $TMP
 
 
-mkdir $TMP
-cd $TMP
+mkdir "$TMP"
+cd "$TMP"
 
 echo
 echo -e "${LIGHT_GREEN} [LOG] Step 02/08 Getting authors ${NC}"
-svn log -q $BASE_SVN | awk -F '|' '/^r/ {sub("^ ", "", $2); sub(" $", "", $2); print $2" = "$2" <"$2"@"$EMAIL">"}' | sort -u >> $AUTHORS
+svn log -q "$BASE_SVN" | awk -F '|' '/^r/ {sub("^ ", "", $2); sub(" $", "", $2); print $2" = "$2" <"$2"@"$EMAIL">"}' | sort -u >> "$AUTHORS"
 
 echo
 echo -e "${LIGHT_GREEN} [RUN] Step 03/08"
-echo 'git svn clone --authors-file='$AUTHORS' --trunk='$TRUNK' --branches='$BRANCHES' --tags='$TAGS $BASE_SVN $TMP
+echo 'git svn clone --authors-file='"$AUTHORS"' --trunk='"$TRUNK"' --branches='"$BRANCHES"' --tags='"$TAGS"' '"$BASE_SVN"' '"$TMP"
 echo -e "${NC}"
 
-git svn clone --authors-file=$AUTHORS --trunk=$TRUNK --branches=$BRANCHES --tags=$TAGS $BASE_SVN $TMP
+git svn clone --authors-file="$AUTHORS" --trunk="$TRUNK" --branches="$BRANCHES" --tags="$TAGS" "$BASE_SVN" "$TMP"
 
 echo
 echo -e "${LIGHT_GREEN} [LOG] Step 04/08  Getting first revision ${NC}"
-FIRST_REVISION=$( svn log -r 1:HEAD --limit 1 $BASE_SVN | awk -F '|' '/^r/ {sub("^ ", "", $1); sub(" $", "", $1); print $1}' )
+FIRST_REVISION=$( svn log -r 1:HEAD --limit 1 "$BASE_SVN" | awk -F '|' '/^r/ {sub("^ ", "", $1); sub(" $", "", $1); print $1}' )
 
 echo
 echo -e "${LIGHT_GREEN} [RUN] Step 05/08 ${NC}"
-echo 'git svn fetch -'$FIRST_REVISION':HEAD'
-git svn fetch -$FIRST_REVISION:HEAD
+echo 'git svn fetch -'"$FIRST_REVISION"':HEAD'
+git svn fetch -"$FIRST_REVISION":HEAD
 
 echo
 echo -e "${LIGHT_GREEN} [RUN] Step 06/08 ${NC}"
-echo 'git remote add origin '$GIT_URL
-git remote add origin $GIT_URL
+echo 'git remote add origin '"$GIT_URL"
+git remote add origin "$GIT_URL"
 
 echo
 echo -e "${LIGHT_GREEN} [RUN] Step 07/08 ${NC}"
-echo 'svn ls '$SVN_BRANCHES
+echo 'svn ls '"$SVN_BRANCHES"
 
-for BRANCH in $(svn ls $SVN_BRANCHES); do
-    echo git branch ${BRANCH%/} remotes/svn/${BRANCH%/}
-    git branch ${BRANCH%/} remotes/svn/${BRANCH%/}
+for BRANCH in $(svn ls "$SVN_BRANCHES"); do
+    pBRANCH="${BRANCH%/}"
+    echo git branch "$pBRANCH" "remotes/origin/$pBRANCH"
+    git branch "$pBRANCH" "remotes/origin/$pBRANCH"
 done
 
-git for-each-ref --format="%(refname:short) %(objectname)" refs/remotes/origin/tags | grep -v "@" | cut -d / -f 3- |
+git for-each-ref --format='%(refname:short) %(objectname)' refs/remotes/origin/tags | grep -v "@" | cut -d / -f 3- |
 while read ref
 do
-  echo git tag -a $ref -m 'import tag from svn'
-  git tag -a $ref -m 'import tag from svn'
+  echo git tag -a "$ref" -m 'import tag from svn'
+  git tag -a "$ref" -m 'import tag from svn'
 done
 
-git for-each-ref --format="%(refname:short)" refs/remotes/origin/tags | cut -d / -f 1- |
+git for-each-ref --format='%(refname:short)' refs/remotes/origin/tags | cut -d / -f 1- |
 while read ref
 do
-  git branch -rd $ref
+  git branch -rd "$ref"
 done
 
 echo
 echo -e "${LIGHT_GREEN} [RUN] Step 08/08 [RUN] git push ${NC}"
+git config http.sslVerify false
 git push origin --all --force
 git push origin --tags
 
-echo 'Sucessufull.'
+echo 'Done.'


### PR DESCRIPTION
Quotes variables that may have spaces on them ensuring the script works if they do, add a local "http.sslVerify false" configuration to the repository so that pushes work against targets with self-signed certificates, fix grammar